### PR TITLE
Fix config file check to properly check each path against isFile instead of list object

### DIFF
--- a/fan_control.py
+++ b/fan_control.py
@@ -92,7 +92,7 @@ def parse_config():
 
     config_path = None
     for path in config['config_paths']:
-        if os.path.isfile(config['config_paths']):
+        if os.path.isfile(path):
             config_path = path
     if not config_path:
         raise RuntimeError("Missing or unspecified configuration file.")


### PR DESCRIPTION
I think a bug was introduced in e7ef694 when specifying which config path to use:

https://github.com/nmaggioni/r710-fan-controller/blob/e7ef6942e028ac3ab0848058e4c864491f2c774e/fan_control.py#L93-L98

The isFile check should check the path in the loop, but is passing in the full list each time.